### PR TITLE
Replace create action with new to avoid Sonata standard links

### DIFF
--- a/src/Admin/SavedFiltersAdmin.php
+++ b/src/Admin/SavedFiltersAdmin.php
@@ -60,8 +60,13 @@ final class SavedFiltersAdmin extends AbstractAdmin
 
     protected function configureRoutes(RouteCollectionInterface $collection): void
     {
-        $collection->clearExcept(['list', 'create']);
+        $collection->clearExcept(['list']);
 
+        $collection->add(
+            name: 'new',
+            pattern: 'new',
+            methods: [Request::METHOD_POST],
+        );
         $collection->add(
             name: 'protect',
             pattern: "{$this->getRouterIdParameter()}/protect",
@@ -87,22 +92,6 @@ final class SavedFiltersAdmin extends AbstractAdmin
             pattern: "{$this->getRouterIdParameter()}/unsubscribe",
             methods: [Request::METHOD_POST],
         );
-    }
-
-    protected function configureDashboardActions(array $actions): array
-    {
-        $actions = parent::configureDashboardActions($actions);
-        unset($actions['create']);
-
-        return $actions;
-    }
-
-    protected function configureActionButtons(array $buttonList, string $action, ?object $object = null): array
-    {
-        $actions = parent::configureActionButtons($buttonList, $action, $object);
-        unset($actions['create']);
-
-        return $actions;
     }
 
     protected function configureListFields(ListMapper $list): void

--- a/src/Controller/SavedFiltersController.php
+++ b/src/Controller/SavedFiltersController.php
@@ -24,11 +24,10 @@ final class SavedFiltersController extends CRUDController
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly SavedFiltersOwnerAccessorInterface $filterSetHolderAccessor,
-        private readonly ValidatorInterface $validator,
     ) {
     }
 
-    public function createAction(Request $request): JsonResponse
+    public function newAction(Request $request, ValidatorInterface $validator): JsonResponse
     {
         $filtersSet = new SavedFilters();
         $filtersSet->setName($request->request->get('name'));
@@ -36,7 +35,7 @@ final class SavedFiltersController extends CRUDController
         $filtersSet->setFilters($request->request->get('filters'));
         $filtersSet->grantOwner($this->owner());
 
-        $violations = $this->validator->validate($filtersSet);
+        $violations = $validator->validate($filtersSet);
         if (count($violations) > 0) {
             return $this->json($violations, Response::HTTP_BAD_REQUEST);
         }

--- a/templates/saved_filters_action.html.twig
+++ b/templates/saved_filters_action.html.twig
@@ -21,7 +21,7 @@
                         <i class="fa fa-plus-circle" aria-hidden="true"></i>
                         {{ 'saved_filters.action.create'|trans }}
                     </a>
-                    <form action="{{ path('presta_sonatasavedfilters_savedfilters_create') }}" class="hidden">
+                    <form action="{{ path('presta_sonatasavedfilters_savedfilters_new') }}" class="hidden">
                         <div class="form-group col-sm-12">
                             <label class="sr-only" for="saved_filters_name">{{ 'saved_filters.field.name'|trans }}</label>
                             <input type="text" id="saved_filters_name" name="saved_filters[name]" placeholder="{{ 'saved_filters.field.name'|trans }}" class="form-control input-sm" />

--- a/tests/Admin/SavedFiltersAdminNewTest.php
+++ b/tests/Admin/SavedFiltersAdminNewTest.php
@@ -8,9 +8,9 @@ use Presta\SonataSavedFiltersBundle\Entity\SavedFilters;
 use Presta\SonataSavedFiltersBundle\Tests\App\User;
 use Symfony\Component\HttpFoundation\Response;
 
-final class SavedFiltersAdminCreateTest extends AdminTestCase
+final class SavedFiltersAdminNewTest extends AdminTestCase
 {
-    public function testCreate(): void
+    public function testNew(): void
     {
         // Given
         self::$doctrine->persist($admin = new User('admin'));
@@ -19,7 +19,7 @@ final class SavedFiltersAdminCreateTest extends AdminTestCase
         self::assertSame(0, self::$doctrine->getRepository(SavedFilters::class)->count([]));
 
         // When
-        self::$client->request('POST', '/presta/sonata-saved-filters/saved-filters/create', [
+        self::$client->request('POST', '/presta/sonata-saved-filters/saved-filters/new', [
             'name' => 'My precious filter',
             'adminClass' => User::class,
             'filters' => 'filter%5Busername%5D%5Bvalue%5D=john',
@@ -31,7 +31,7 @@ final class SavedFiltersAdminCreateTest extends AdminTestCase
         self::assertSame(1, self::$doctrine->getRepository(SavedFilters::class)->count([]));
     }
 
-    public function testCreateInvalid(): void
+    public function testNewInvalid(): void
     {
         // Given
         self::$doctrine->persist($admin = new User('admin'));
@@ -40,7 +40,7 @@ final class SavedFiltersAdminCreateTest extends AdminTestCase
         self::assertSame(0, self::$doctrine->getRepository(SavedFilters::class)->count([]));
 
         // When
-        self::$client->request('POST', '/presta/sonata-saved-filters/saved-filters/create', [
+        self::$client->request('POST', '/presta/sonata-saved-filters/saved-filters/new', [
             'name' => null,
             'adminClass' => null,
             'filters' => null,
@@ -52,13 +52,13 @@ final class SavedFiltersAdminCreateTest extends AdminTestCase
         self::assertSame(0, self::$doctrine->getRepository(SavedFilters::class)->count([]));
     }
 
-    public function testCreateNotAuthenticated(): void
+    public function testNewNotAuthenticated(): void
     {
         // Given
         self::assertSame(0, self::$doctrine->getRepository(SavedFilters::class)->count([]));
 
         // When
-        self::$client->request('POST', '/presta/sonata-saved-filters/saved-filters/create');
+        self::$client->request('POST', '/presta/sonata-saved-filters/saved-filters/new');
 
         // Then
         self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);


### PR DESCRIPTION
I discovered more places where the create button is trying to be displayed:
- quick create menu
- empty list
- ...

I believe it is just safer to rename the action